### PR TITLE
vyatta-bash: import patch from Redhat for CVE-2014-7169

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -261,8 +261,18 @@ int parser_state;
 
 /* Variables to manage the task of reading here documents, because we need to
    defer the reading until after a complete command has been collected. */
-static REDIRECT *redir_stack[10];
+static REDIRECT **redir_stack;
 int need_here_doc;
+
+/* Pushes REDIR onto redir_stack, resizing it as needed. */
+static void push_redir_stack (REDIRECT *redir)
+{
+  /* Guard against oveflow. */
+  if (need_here_doc + 1 > INT_MAX / sizeof (*redir_stack))
+    abort ();
+  redir_stack = xrealloc (redir_stack, (need_here_doc + 1) * sizeof (*redir_stack));
+  redir_stack[need_here_doc++] = redir;
+}
 
 /* Where shell input comes from.  History expansion is performed on each
    line when the shell is interactive. */
@@ -516,42 +526,42 @@ redirection:	'>' WORD
 			  source.dest = 0;
 			  redir.filename = $2;
 			  $$ = make_redirection (source, r_reading_until, redir, 0);
-			  redir_stack[need_here_doc++] = $$;
+			  push_redir_stack ($$);
 			}
 	|	NUMBER LESS_LESS WORD
 			{
 			  source.dest = $1;
 			  redir.filename = $3;
 			  $$ = make_redirection (source, r_reading_until, redir, 0);
-			  redir_stack[need_here_doc++] = $$;
+			  push_redir_stack ($$);
 			}
 	|	REDIR_WORD LESS_LESS WORD
 			{
 			  source.filename = $1;
 			  redir.filename = $3;
 			  $$ = make_redirection (source, r_reading_until, redir, REDIR_VARASSIGN);
-			  redir_stack[need_here_doc++] = $$;
+			  push_redir_stack ($$);
 			}
 	|	LESS_LESS_MINUS WORD
 			{
 			  source.dest = 0;
 			  redir.filename = $2;
 			  $$ = make_redirection (source, r_deblank_reading_until, redir, 0);
-			  redir_stack[need_here_doc++] = $$;
+			  push_redir_stack ($$);
 			}
 	|	NUMBER LESS_LESS_MINUS WORD
 			{
 			  source.dest = $1;
 			  redir.filename = $3;
 			  $$ = make_redirection (source, r_deblank_reading_until, redir, 0);
-			  redir_stack[need_here_doc++] = $$;
+			  push_redir_stack ($$);
 			}
 	|	REDIR_WORD  LESS_LESS_MINUS WORD
 			{
 			  source.filename = $1;
 			  redir.filename = $3;
 			  $$ = make_redirection (source, r_deblank_reading_until, redir, REDIR_VARASSIGN);
-			  redir_stack[need_here_doc++] = $$;
+			  push_redir_stack ($$);
 			}
 	|	LESS_LESS_LESS WORD
 			{
@@ -4746,7 +4756,7 @@ got_token:
     case CASE:
     case SELECT:
     case FOR:
-      if (word_top < MAX_CASE_NEST)
+      if (word_top + 1 < MAX_CASE_NEST)
 	word_top++;
       word_lineno[word_top] = line_number;
       break;

--- a/variables.c
+++ b/variables.c
@@ -268,7 +268,7 @@ static void push_temp_var __P((PTR_T));
 static void propagate_temp_var __P((PTR_T));
 static void dispose_temporary_env __P((sh_free_func_t *));     
 
-static inline char *mk_env_string __P((const char *, const char *));
+static inline char *mk_env_string __P((const char *, const char *, int));
 static char **make_env_array_from_var_list __P((SHELL_VAR **));
 static char **make_var_export_array __P((VAR_CONTEXT *));
 static char **make_func_export_array __P((void));
@@ -300,6 +300,13 @@ create_variable_tables ()
     shell_function_defs = hash_create (0);
 #endif
 }
+
+/* Prefix and suffix for environment variable names which contain
+ shell functions. */
+#define FUNCDEF_PREFIX "BASH_FUNC_"
+#define FUNCDEF_PREFIX_LEN (strlen (FUNCDEF_PREFIX))
+#define FUNCDEF_SUFFIX "()"
+#define FUNCDEF_SUFFIX_LEN (strlen (FUNCDEF_SUFFIX))
 
 /* Initialize the shell variables from the current environment.
    If PRIVMODE is nonzero, don't import functions from ENV or
@@ -338,28 +345,38 @@ initialize_shell_variables (env, privmode)
 
       /* If exported function, define it now.  Don't import functions from
 	 the environment in privileged mode. */
-      if (privmode == 0 && read_but_dont_execute == 0 && STREQN ("() {", string, 4))
-	{
-	  string_length = strlen (string);
-	  temp_string = (char *)xmalloc (3 + string_length + char_index);
+      if (privmode == 0 && read_but_dont_execute == 0
+	&& STREQN (FUNCDEF_PREFIX, name, FUNCDEF_PREFIX_LEN)
+	&& STREQ (name + char_index - FUNCDEF_SUFFIX_LEN, FUNCDEF_SUFFIX)
+	&& STREQN ("() {", string, 4))
+      {
+	size_t name_length = char_index - (FUNCDEF_PREFIX_LEN + FUNCDEF_SUFFIX_LEN);
+	char *temp_name = name + FUNCDEF_PREFIX_LEN;
+	/* Temporarily remove the suffix. */
+	temp_name[name_length] = '\0';
 
-	  strcpy (temp_string, name);
-	  temp_string[char_index] = ' ';
-	  strcpy (temp_string + char_index + 1, string);
+	string_length = strlen (string);
+	temp_string = (char *)xmalloc (name_length + 1 + string_length + 1);
+	memcpy (temp_string, temp_name, name_length);
+	temp_string[name_length] = ' ';
+	memcpy (temp_string + name_length + 1, string, string_length + 1);
 
-	  /* Don't import function names that are invalid identifiers from the
-	     environment. */
-	  if (legal_identifier (name))
-	    parse_and_execute (temp_string, name, SEVAL_NONINT|SEVAL_NOHIST|SEVAL_FUNCDEF|SEVAL_ONECMD);
+	/* Don't import function names that are invalid identifiers from the
+	   environment. */
+	if (legal_identifier (temp_name))
+	  parse_and_execute (temp_string, temp_name, SEVAL_NONINT|SEVAL_NOHIST|SEVAL_FUNCDEF|SEVAL_ONECMD);
 
-	  if (temp_var = find_function (name))
-	    {
-	      VSETATTR (temp_var, (att_exported|att_imported));
-	      array_needs_making = 1;
-	    }
-	  else
-	    report_error (_("error importing function definition for `%s'"), name);
-	}
+	if (temp_var = find_function (temp_name))
+	  {
+	    VSETATTR (temp_var, (att_exported|att_imported));
+	    array_needs_making = 1;
+	  }
+	else
+	  report_error (_("error importing function definition for `%s'"), name);
+
+	/* Restore the original suffix. */
+	temp_name[name_length] = FUNCDEF_SUFFIX[0];
+      }
 #if defined (ARRAY_VARS)
 #  if 0
       /* Array variables may not yet be exported. */
@@ -2519,7 +2536,7 @@ assign_in_env (word)
   var->context = variable_context;	/* XXX */
 
   INVALIDATE_EXPORTSTR (var);
-  var->exportstr = mk_env_string (name, value);
+  var->exportstr = mk_env_string (name, value, 0);
 
   array_needs_making = 1;
 
@@ -3337,22 +3354,43 @@ merge_temporary_env ()
 /*								    */
 /* **************************************************************** */
 
+/* Returns the string NAME=VALUE if !FUNCTIONP or if VALUE == NULL (in
+   which case it is treated as empty). Otherwise, decorate NAME with
+   FUNCDEF_PREFIX and FUNCDEF_SUFFIX, and return a string of the form
+   FUNCDEF_PREFIX NAME FUNCDEF_SUFFIX = VALUE (without spaces). */
+
 static inline char *
-mk_env_string (name, value)
+mk_env_string (name, value, functionp)
      const char *name, *value;
+     int functionp;
 {
-  int name_len, value_len;
-  char	*p;
+  size_t name_len, value_len;
+  char *p, *q;
 
   name_len = strlen (name);
   value_len = STRLEN (value);
-  p = (char *)xmalloc (2 + name_len + value_len);
-  strcpy (p, name);
-  p[name_len] = '=';
+  if (functionp && value != NULL)
+    {
+      p = (char *)xmalloc (FUNCDEF_PREFIX_LEN + name_len + FUNCDEF_SUFFIX_LEN + 1 + value_len + 1);
+      q = p;
+      memcpy (q, FUNCDEF_PREFIX, FUNCDEF_PREFIX_LEN);
+      q += FUNCDEF_PREFIX_LEN;
+      memcpy (q, name, name_len);
+      q += name_len;
+      memcpy (q, FUNCDEF_SUFFIX, FUNCDEF_SUFFIX_LEN);
+      q += FUNCDEF_SUFFIX_LEN;
+    }
+    else
+    {
+      p = (char *)xmalloc (name_len + 1 + value_len + 1);
+      memcpy (p, name, name_len);
+      q = p + name_len;
+    }
+  q[0] = '=';
   if (value && *value)
-    strcpy (p + name_len + 1, value);
+    memcpy (q + 1, value, value_len + 1);
   else
-    p[name_len + 1] = '\0';
+    q[1] = '\0';
   return (p);
 }
 
@@ -3437,8 +3475,7 @@ make_env_array_from_var_list (vars)
 	{
 	  /* Gee, I'd like to get away with not using savestring() if we're
 	     using the cached exportstr... */
-	  list[list_index] = USE_EXPORTSTR ? savestring (value)
-					   : mk_env_string (var->name, value);
+	  list[list_index] = USE_EXPORTSTR ? savestring (value) : mk_env_string (var->name, value, function_p (var));
 
 	  if (USE_EXPORTSTR == 0)
 	    SAVE_EXPORTSTR (var, list[list_index]);


### PR DESCRIPTION
Import the patch from RedHat to fix CVE-2014-7169, reported following
the fix for CVE-2014-6271 that didn't completely fix the issue.

Related to Bug #324

Bug #326 http://bugzilla.vyos.net/show_bug.cgi?id=326
