### PR TITLE
T8943: sweep HIGH-producer pins to renamed branches (rollout 1c)

### DIFF
--- a/.github/workflows/chceck-pr-message.yml
+++ b/.github/workflows/chceck-pr-message.yml
@@ -16,5 +16,5 @@
   
   jobs:
     check-pr-title:
-      uses: vyos/.github/.github/workflows/check-pr-message.yml@current
+      uses: vyos/.github/.github/workflows/check-pr-message.yml@production
       secrets: inherit

--- a/.github/workflows/check-pr-conflicts.yml
+++ b/.github/workflows/check-pr-conflicts.yml
@@ -9,5 +9,5 @@ permissions:
 
 jobs:
   check-pr-conflict-call:
-    uses: vyos/.github/.github/workflows/check-pr-merge-conflict.yml@current
+    uses: vyos/.github/.github/workflows/check-pr-merge-conflict.yml@production
     secrets: inherit

--- a/.github/workflows/check-stale.yml
+++ b/.github/workflows/check-stale.yml
@@ -9,5 +9,5 @@ permissions:
 
 jobs:
   stale:
-    uses: vyos/.github/.github/workflows/check-stale.yml@current
+    uses: vyos/.github/.github/workflows/check-stale.yml@production
     secrets: inherit

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -14,5 +14,5 @@ on:
 
 jobs:
   call-cla-assistant:
-    uses: vyos/vyos-cla-signatures/.github/workflows/cla-reusable.yml@current
+    uses: vyos/vyos-cla-signatures/.github/workflows/cla-reusable.yml@production
     secrets: inherit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   codeql-analysis-call:
-    uses: vyos/.github/.github/workflows/codeql-analysis.yml@current
+    uses: vyos/.github/.github/workflows/codeql-analysis.yml@production
     secrets: inherit
     with:
       languages: "['c']"

--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -24,7 +24,7 @@ jobs:
       github.repository_owner == 'vyos'
       && (github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch')
       && vars.MIRROR_ENABLED != 'false'
-    uses: vyos/.github/.github/workflows/pr-mirror-repo-sync.yml@current
+    uses: vyos/.github/.github/workflows/pr-mirror-repo-sync.yml@production
     with:
       sync_branch: ${{ inputs.sync_branch || github.event.pull_request.base.ref }}
     secrets: inherit

--- a/.github/workflows/trigger-rebuild-repo-package.yml
+++ b/.github/workflows/trigger-rebuild-repo-package.yml
@@ -23,7 +23,7 @@ jobs:
 
   trigger-build:
     needs: get_repo_name
-    uses: vyos/.github/.github/workflows/trigger-rebuild-repo-package.yml@current
+    uses: vyos/.github/.github/workflows/trigger-rebuild-repo-package.yml@production
     with:
       branch: ${{ github.event.pull_request.base.ref }}
       package_name: ${{ needs.get_repo_name.outputs.PACKAGE_NAME }}


### PR DESCRIPTION
Rollout 1c Task 2 — target-aware HIGH-producer pin sweep. Rewrites `uses:` pins to vyos/.github, vyos/vyos-cla-signatures, and VyOS-Networks/vyos-reusable-workflows from their old default branch to the `production` compat branch (staged in Task 1). No functional change; canary (vyos/vyos-1x#5240) Phase-0-clean. Kept draft to avoid redundant bot CodeRabbit cycles; admin-merged. Tracking: T8943