### PR TITLE
ci: T8943: re-add PR-mirror wrapper stub (rolling)

### DIFF
--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -1,0 +1,27 @@
+# .github/workflows/pr-mirror-repo-sync.yml
+# DO NOT EDIT — managed by mirror-pipeline rollout.
+# To opt out: set vars.MIRROR_ENABLED=false in this repo's Actions variables.
+name: PR Mirror and Repo Sync
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches: [rolling, production]
+  workflow_dispatch:
+    inputs:
+      sync_branch:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  call:
+    if: |
+      github.repository_owner == 'vyos'
+      && (github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch')
+    uses: vyos/.github/.github/workflows/pr-mirror-repo-sync.yml@production
+    with:
+      sync_branch: ${{ inputs.sync_branch || github.event.pull_request.base.ref }}
+    secrets: inherit


### PR DESCRIPTION
## What

Re-adds the canonical PR-mirror wrapper stub `.github/workflows/pr-mirror-repo-sync.yml`, re-onboarding `vyatta-bash` to the mirror pipeline (**rolling-only**).

Reverses the 2026-05-30 exclusion (VD-4257 c#46015 — *"eventual removal"*). The wrapper was removed in Rollout 2 Task 7 ([#36](https://github.com/vyos/vyatta-bash/pull/36)); this restores it because the repo is active again (not archived; pushed 2026-06-05).

## Detail

- File is **byte-identical** to the canonical managed stub used across all 36 consumers (sha256 `45634ff9`), fetched verbatim from `vyos/vyos-1x@rolling`.
- Paired with the `consumers.yaml` allow-list entry on `VyOS-Networks/.github` ([VyOS-Networks/.github#24](https://github.com/VyOS-Networks/.github/pull/24)). Mirroring no-ops until **both** land (the reusable short-circuits `mirror-skipped` if the repo isn't in `consumers.yaml`).

## CodeRabbit finding — pushed back (not applied)

Phase 0 CodeRabbit flagged "pin the reusable to a commit SHA instead of `@production`." **Declined intentionally:** this is the managed canonical stub — all 36 consumers use the mutable `@production` ref by design, so central workflow updates propagate fleet-wide without re-pinning each consumer. SHA-pinning would break the byte-identical invariant and defeat the central-config model. Keeping it identical to the fleet.

## Verification

- sha256 matches canonical (`45634ff9`).
- Phase 0 local CodeRabbit: 1 finding, pushed back as above (managed-stub exception).

Refs: [VD-4257](https://vyos.atlassian.net/browse/VD-4257), T8943

🤖 Generated by [robots](https://vyos.io)

[VD-4257]: https://vyos.atlassian.net/browse/VD-4257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ